### PR TITLE
Fixed negative transactions

### DIFF
--- a/lib/blockchain/transaction.js
+++ b/lib/blockchain/transaction.js
@@ -84,9 +84,9 @@ class Transaction {
             let i = 0;
             let outputsLen = this.data.outputs.length;
 
-            // Check for empty or negative outputs
+            // Check for negative outputs
             for (i = 0; i < outputsLen; i++) {
-                if (this.data.outputs[i].amount < 0.00000001) {
+                if (this.data.outputs[i].amount < 0) {
                     negativeOutputsFound++;
                 }
             }

--- a/lib/blockchain/transaction.js
+++ b/lib/blockchain/transaction.js
@@ -79,6 +79,17 @@ class Transaction {
             // Check if the sum of input transactions are greater than output transactions, it needs to leave some room for the transaction fee
             let sumOfInputsAmount = R.sum(R.map(R.prop('amount'), this.data.inputs));
             let sumOfOutputsAmount = R.sum(R.map(R.prop('amount'), this.data.outputs));
+            
+            let negativeOutputsFound = 0
+            let i = 0
+            let outputsLen = this.data.outputs.length
+
+            // Check for empty or negative outputs
+            for (i = 0; i < outputsLen; i++) {
+                if (this.data.outputs[i].amount < 0.00000001) {
+                    negativeOutputsFound++
+                }
+            }
 
             let isInputsAmountGreaterOrEqualThanOutputsAmount = R.gte(sumOfInputsAmount, sumOfOutputsAmount);
 
@@ -92,6 +103,10 @@ class Transaction {
             if (!isEnoughFee) {
                 console.error(`Not enough fee: expected '${Config.FEE_PER_TRANSACTION}' got '${(sumOfInputsAmount - sumOfOutputsAmount)}'`);
                 throw new TransactionAssertionError(`Not enough fee: expected '${Config.FEE_PER_TRANSACTION}' got '${(sumOfInputsAmount - sumOfOutputsAmount)}'`, { sumOfInputsAmount, sumOfOutputsAmount, FEE_PER_TRANSACTION: Config.FEE_PER_TRANSACTION });
+            }
+            if (negativeOutputsFound > 0) {
+                console.error(`Transaction is either empty or negative, output(s) caught: '${negativeOutputsFound}'`)
+                throw new TransactionAssertionError(`Transaction is either empty or negative, output(s) caught: '${negativeOutputsFound}'`)
             }
         }
 

--- a/lib/blockchain/transaction.js
+++ b/lib/blockchain/transaction.js
@@ -80,14 +80,14 @@ class Transaction {
             let sumOfInputsAmount = R.sum(R.map(R.prop('amount'), this.data.inputs));
             let sumOfOutputsAmount = R.sum(R.map(R.prop('amount'), this.data.outputs));
             
-            let negativeOutputsFound = 0
-            let i = 0
-            let outputsLen = this.data.outputs.length
+            let negativeOutputsFound = 0;
+            let i = 0;
+            let outputsLen = this.data.outputs.length;
 
             // Check for empty or negative outputs
             for (i = 0; i < outputsLen; i++) {
                 if (this.data.outputs[i].amount < 0.00000001) {
-                    negativeOutputsFound++
+                    negativeOutputsFound++;
                 }
             }
 
@@ -105,8 +105,8 @@ class Transaction {
                 throw new TransactionAssertionError(`Not enough fee: expected '${Config.FEE_PER_TRANSACTION}' got '${(sumOfInputsAmount - sumOfOutputsAmount)}'`, { sumOfInputsAmount, sumOfOutputsAmount, FEE_PER_TRANSACTION: Config.FEE_PER_TRANSACTION });
             }
             if (negativeOutputsFound > 0) {
-                console.error(`Transaction is either empty or negative, output(s) caught: '${negativeOutputsFound}'`)
-                throw new TransactionAssertionError(`Transaction is either empty or negative, output(s) caught: '${negativeOutputsFound}'`)
+                console.error(`Transaction is either empty or negative, output(s) caught: '${negativeOutputsFound}'`);
+                throw new TransactionAssertionError(`Transaction is either empty or negative, output(s) caught: '${negativeOutputsFound}'`);
             }
         }
 

--- a/lib/miner/index.js
+++ b/lib/miner/index.js
@@ -65,6 +65,16 @@ class Miner {
         let rejectedTransactions = [];
         let selectedTransactions = [];
         R.forEach((transaction) => {
+            let negativeOutputsFound = 0
+            let i = 0
+            let outputsLen = transaction.data.outputs.length
+
+            // Check for empty or negative outputs (avoiding negative transactions or 'stealing')
+            for (i = 0; i < outputsLen; i++) {
+                if (transaction.data.outputs[i].amount < 0.00000001) {
+                    negativeOutputsFound++
+                }
+            }
             // Check if any of the inputs is found in the selectedTransactions or in the blockchain
             let transactionInputFoundAnywhere = R.map((input) => {
                 let findInputTransactionInTransactionList = R.find(
@@ -82,11 +92,16 @@ class Miner {
                 return wasItFoundInSelectedTransactions || wasItFoundInBlocks;
             }, transaction.data.inputs);
 
-            // If no input was found, add the transaction to the transaction list to be mined
             if (R.all(R.equals(false), transactionInputFoundAnywhere)) {
-                selectedTransactions.push(transaction);
+                if (transaction.type === 'regular' && negativeOutputsFound === 0) {
+                    selectedTransactions.push(transaction)
+                } else if (transaction.type === 'reward') {
+                    selectedTransactions.push(transaction)
+                } else if (negativeOutputsFound > 0) {
+                    rejectedTransactions.push(transaction)
+                }
             } else {
-                rejectedTransactions.push(transaction);
+                rejectedTransactions.push(transaction)
             }
         }, candidateTransactions);
 

--- a/lib/miner/index.js
+++ b/lib/miner/index.js
@@ -35,9 +35,20 @@ class Miner {
         )(baseBlock.transactions);
 
         console.info(`Mining a new block with ${baseBlock.transactions.length} (${transactionList}) transactions`);
-        return thread
-            .send({ __dirname: __dirname, logLevel: this.logLevel, jsonBlock: baseBlock, difficulty: this.blockchain.getDifficulty() })
-            .promise();
+
+        const promise = thread.promise().then((result) => {
+            thread.kill();
+            return result;
+        });
+
+        thread.send({
+            __dirname: __dirname,
+            logLevel: this.logLevel,
+            jsonBlock: baseBlock,
+            difficulty: this.blockchain.getDifficulty()
+        });
+
+        return promise;
     }
 
     static generateNextBlock(rewardAddress, feeAddress, blockchain) {

--- a/lib/miner/index.js
+++ b/lib/miner/index.js
@@ -69,9 +69,9 @@ class Miner {
             let i = 0;
             let outputsLen = transaction.data.outputs.length;
 
-            // Check for empty or negative outputs (avoiding negative transactions or 'stealing')
+            // Check for negative outputs (avoiding negative transactions or 'stealing')
             for (i = 0; i < outputsLen; i++) {
-                if (transaction.data.outputs[i].amount < 0.00000001) {
+                if (transaction.data.outputs[i].amount < 0) {
                     negativeOutputsFound++;
                 }
             }

--- a/lib/miner/index.js
+++ b/lib/miner/index.js
@@ -65,14 +65,14 @@ class Miner {
         let rejectedTransactions = [];
         let selectedTransactions = [];
         R.forEach((transaction) => {
-            let negativeOutputsFound = 0
-            let i = 0
-            let outputsLen = transaction.data.outputs.length
+            let negativeOutputsFound = 0;
+            let i = 0;
+            let outputsLen = transaction.data.outputs.length;
 
             // Check for empty or negative outputs (avoiding negative transactions or 'stealing')
             for (i = 0; i < outputsLen; i++) {
                 if (transaction.data.outputs[i].amount < 0.00000001) {
-                    negativeOutputsFound++
+                    negativeOutputsFound++;
                 }
             }
             // Check if any of the inputs is found in the selectedTransactions or in the blockchain
@@ -94,14 +94,14 @@ class Miner {
 
             if (R.all(R.equals(false), transactionInputFoundAnywhere)) {
                 if (transaction.type === 'regular' && negativeOutputsFound === 0) {
-                    selectedTransactions.push(transaction)
+                    selectedTransactions.push(transaction);
                 } else if (transaction.type === 'reward') {
-                    selectedTransactions.push(transaction)
+                    selectedTransactions.push(transaction);
                 } else if (negativeOutputsFound > 0) {
-                    rejectedTransactions.push(transaction)
+                    rejectedTransactions.push(transaction);
                 }
             } else {
-                rejectedTransactions.push(transaction)
+                rejectedTransactions.push(transaction);
             }
         }, candidateTransactions);
 


### PR DESCRIPTION
While messing around and testing the blockchain on my Naivecoin fork, I discovered it was possible to send "negative transactions", basically... you could 'steal' from any address, if you sent a minus transaction to them, even if that address didn't have those coins, or if the address didn't yet exist.

This means you could effectively create coins from thin air, just by adding a - onto the front of your transaction amount.

E.G: Sending -50 to bob --> bob loses 50 coins and you gain 50 coins. (Screenshot below will explain this visually, using the block-explorer)

![image](https://user-images.githubusercontent.com/42538664/50034194-9531ba00-fff3-11e8-9d99-ee3badceea59.png)

This PR will fix this by looping through outputs of every regular transaction (Fee and Reward transactions are not checked), and if it encounters a negative output, the transaction is rejected. This is built into both Transaction.js and the miner index.

Hope this helps!! This is my first code commit to another project, take it easy on me! <3